### PR TITLE
Features/improvements for vocabulary

### DIFF
--- a/rslang/src/js/components/vocabulary/Vocabulary.js
+++ b/rslang/src/js/components/vocabulary/Vocabulary.js
@@ -176,12 +176,24 @@ class Vocabulary {
     this.renderVocabulary(vocabulary);
   }
 
-  getWordsByVocabularyType(vocabularyType) {
-    return this.state.allUserWords.filter((word) => word.optional.vocabulary === vocabularyType);
+  getWordsByVocabularyType(vocabularyType, getNormalObject = false) {
+    const wordsArr = this.state.allUserWords.filter((word) => word.optional.vocabulary === vocabularyType);
+    return (getNormalObject) ? wordsArr.map((word) => word.optional.allData) : wordsArr;
   }
 
-  getAllVocabulariesData() {
-    return this.state.vocabularies;
+  getAllVocabulariesData(getNormalObjects = false) {
+    let vocabulariesWordsObject;
+    if (getNormalObjects) {
+      vocabulariesWordsObject = {
+        wordsToLearn: this.state.vocabularies.wordsToLearn.map((word) => word.optional.allData),
+        learnedWords: this.state.vocabularies.learnedWords.map((word) => word.optional.allData),
+        removedWords: this.state.vocabularies.removedWords.map((word) => word.optional.allData),
+        difficultWords: this.state.vocabularies.difficultWords.map((word) => word.optional.allData),
+      };
+    } else {
+      vocabulariesWordsObject = this.state.vocabularies;
+    }
+    return vocabulariesWordsObject;
   }
 
   getVocabularyWordsLength(vocabularyType) {


### PR DESCRIPTION
Так как сервер для пользовательского словаря требует и возвращает видоизмененные объекты слов, слегка обновил модуль словаря. Теперь в каждой игре есть возможность получения объекта слов в стандартном виде (таком же, как и объекты из `getWords()`).
Чтобы получить "нормализованный" объект, необходимо при вызове методов `getWordsByVocabularyType` или `getAllVocabulariesData` передать в качестве аргумента `true`:
`words = this.Vocabulary.getWordsByVocabularyType(LEARNED_WORDS_TITLE, true);`
или
`wordsInAllVocabularies =  this.Vocabulary.getAllVocabulariesData(true);`

Если вы уже самостоятельно приводите объект к нормальному виду - для вас ничего не изменится.