### PR TITLE
fixes/ShortTermStatistics

### DIFF
--- a/rslang/src/js/components/mini-games/common/ShortTermStatistics.js
+++ b/rslang/src/js/components/mini-games/common/ShortTermStatistics.js
@@ -28,9 +28,9 @@ export default class ShortTermStatistics extends ModalWindow {
 
     ShortTermStatistics.clearstatisticaWords();
 
-    this.statisticaWrongWordsText = create('p', 'modal_title', `${ERROR_STAT} ${wrongWords.length}`, this.modalText);
+    this.statisticaWrongWordsText = create('p', 'modal_title', `${ERROR_STAT} ${wrongWords.length}`, this.modalText, ['id', 'short_term_wrong_words']);
     this.statisticaWrongWords = create('p', 'modal_words', '', this.statisticaWrongWordsText);
-    this.statisticaRightWordsText = create('p', 'modal_title', `${CORRECT_STAT} ${rightWords.length}`, this.modalText);
+    this.statisticaRightWordsText = create('p', 'modal_title', `${CORRECT_STAT} ${rightWords.length}`, this.modalText, ['id', 'short_term_right_words']);
     this.statisticaRightWords = create('p', 'modal_words', '', this.statisticaRightWordsText);
 
     ShortTermStatistics.statisticaWords(wrongWords, this.statisticaWrongWords);


### PR DESCRIPTION
В процессе тестирования своей игры выявил и исправил ошибки с ShortTermStatistics:

1. не появляется окно при повторном старте игры, если в прошлый раз игра была успешно завершена.
2. если статистика появляется несколько раз подряд, то результаты игры добавлялись, а не обновлялись.

Данные исправления не должны повлиять на работу вашего приложения, но лучше перепроверить.