### PR TITLE
fix: charts render in Statistics

### DIFF
--- a/rslang/src/js/components/statistics/Chart.js
+++ b/rslang/src/js/components/statistics/Chart.js
@@ -15,6 +15,12 @@ export default class StatisticsChart {
     return this.myDiv;
   }
 
+  clearRenderedCharts() {
+    if (this.myDiv) {
+      this.myDiv.innerHTML = '';
+    }
+  }
+
   learnedWordsChart(learnedWords, learnedWordsObj) {
     const div = create('div', 'mainChart', '', this.myDiv);
     const ctx = create('canvas', 'myChart', '', div);

--- a/rslang/src/js/components/statistics/Statistics.js
+++ b/rslang/src/js/components/statistics/Statistics.js
@@ -233,6 +233,8 @@ export default class Statistics {
     const learnedWordsData = this.getLearnedWordsByDate();
     const summaryByAnswers = this.getSummaryByAnswers();
     const summaryByGames = this.getSummaryByGames();
+
+    this.chrt.clearRenderedCharts();
     this.chrt.summaryByAnswersChart(summaryByAnswers);
     this.chrt.summaryByGamesChart(summaryByGames);
     this.chrt.learnedWordsChart(this.statistics.learnedWords, learnedWordsData);


### PR DESCRIPTION
Фикс рендера графиков долгосрочной статистики: при открытии страницы статистики, графики "дорисовывались" каждый раз