### PR TITLE
Hotfix/exit button in find a pair and statistics

### DIFF
--- a/rslang/src/js/components/mini-games/sprint/Sprint.js
+++ b/rslang/src/js/components/mini-games/sprint/Sprint.js
@@ -39,7 +39,6 @@ export default class SprintGame {
     this.closeButton = miniGameParameters.closeButton;
     this.shortTermStatistics = miniGameParameters.shortTermStatistics;
 
-    this.closeButton.exitButton.classList.add('sprint__exit-button');
     this.closeButton.addCloseCallbackFn((this.Home).bind(this));
     this.closeButton.addExitButtonClickCallbackFn((this.pauseGame).bind(this));
     this.closeButton.addCancelCallbackFn((this.pauseGame).bind(this));

--- a/rslang/src/scss/components/mini-games/find-a-pair/find-a-pair.scss
+++ b/rslang/src/scss/components/mini-games/find-a-pair/find-a-pair.scss
@@ -10,6 +10,7 @@
 }
 
 .find-a-pair__container {
+  position: relative;
   border: 1px solid $find-a-pair-border-color;
   border-radius: 15px;
   padding: 15px;
@@ -17,6 +18,10 @@
   margin: 0 auto;
   width: auto;
   max-width: $content-width;
+
+  & .exit-button {
+      top: 17px;
+  }
   @include media-tablet {
     min-width: 285px;
   }

--- a/rslang/src/scss/components/mini-games/sprint/sprint.scss
+++ b/rslang/src/scss/components/mini-games/sprint/sprint.scss
@@ -28,16 +28,16 @@
 		margin: 10%;
 		border: 5px solid white;
 		background: transparent;
-	}
+  }
+
+  & .exit-button {
+    top: 9px;
+    right: 30px;
+  }
 }
 
 .sprint__start-game-window {
 	width: 55%;
-}
-
-.sprint__exit-button {
-	top: 9px;
-	right: 30px;
 }
 
 .game-choice {

--- a/rslang/src/scss/components/statistics/statistics.scss
+++ b/rslang/src/scss/components/statistics/statistics.scss
@@ -87,6 +87,7 @@
   position: relative;
   border-left: 1.5px solid $statistics-border-color;
   border-right: 1.5px solid $statistics-border-color;
+
   &::before {
     content: '';
     position: absolute;
@@ -95,6 +96,7 @@
     top: 0;
     left: 0;
   }
+
   &::after {
     content: '';
     position: absolute;
@@ -150,12 +152,13 @@
     width: 100%;
   }
 }
+
 @media only screen and (max-width: 475px) {
   .statistics__container {
     margin-top: 30px;
   }
 
-  .exit-button {
+  .statistics__exit-button {
     top: 40px;
   }
 


### PR DESCRIPTION
Исправлено:
1) имя класса для exit-button в Statistics.scss, из-за чего кнопка везде смещалась вниз во всех модулях.
2) положение exit-button в игре find-a-pair. Привязал её к общему контейнеру
3) убрал класс из Sprint для exit-button, перенес стили для неё во wrapper. 

Все изменения можно сравнить и проверить тут: https://elegant-morse-a860ab.netlify.app