### PR TITLE
Fix english-puzzle styles and problem with vocabulary, and added async/await for AuditionGame in App

### DIFF
--- a/rslang/src/js/components/app/App.js
+++ b/rslang/src/js/components/app/App.js
@@ -210,7 +210,7 @@ class App {
         await this.renderEnglishPuzzle();
         break;
       case audioGame.code:
-        this.renderAuditionGame();
+        await this.renderAuditionGame();
         break;
       case savannah.code:
         await this.renderSavannah();
@@ -271,13 +271,13 @@ class App {
     await this.englishPuzzle.start('.main-page__content');
   }
 
-  renderAuditionGame() {
+  async renderAuditionGame() {
     if (!this.auditionGame) {
       this.auditionGame = new AuditionGame(
         this.createMiniGameParameterObject(), this.container,
       );
     }
-    this.auditionGame.render();
+    await this.auditionGame.render();
   }
 
   async renderSavannah() {

--- a/rslang/src/js/components/mini-games/english-puzzle/EnglishPuzzle.js
+++ b/rslang/src/js/components/mini-games/english-puzzle/EnglishPuzzle.js
@@ -61,17 +61,13 @@ export default class EnglishPuzzle {
     await this.statistics.init();
 
     const gameZone = new MainBlock();
-    const startWindow = new StartWindow((this.startMenuButtonAction).bind(this));
-    startWindow.gameWindow.classList.add('english-puzzle__start-game-window');
+    this.startWindow = new StartWindow((this.startMenuButtonAction).bind(this));
+    this.startWindow.gameWindow.classList.add('english-puzzle__start-game-window');
     this.gameForm = gameZone.createMainForm();
     this.backData.closeButton.show();
     this.gameForm.appendChild(this.backData.closeButton.render());
-
-    this.words = this.vocabulary.getWordsByVocabularyType(vocabularyConstants.LEARNED_WORDS_TITLE);
-    const isShowLearnedWordsOption = this.words.length >= GAME_BLOCK.gameZoneRows;
-    this.startMenu = create('div', 'start-window', startWindow.render(
-      START_WINDOW.title, START_WINDOW.description, isShowLearnedWordsOption,
-    ));
+    this.startMenu = create('div', 'start-window');
+    await this.checkWordsCollections();
 
     this.preloader.render();
 
@@ -82,6 +78,14 @@ export default class EnglishPuzzle {
     this.backData.closeButton.addCloseCallbackFn((this.actionOnCloseButton).bind(this));
     this.actionsOnSupportButtons();
     this.controlButtonsAction();
+  }
+
+  async checkWordsCollections() {
+    cleanParentNode(this.startMenu);
+    this.words = this.vocabulary.getWordsByVocabularyType(vocabularyConstants.LEARNED_WORDS_TITLE);
+    const isShowLearnedWordsOption = this.words.length >= GAME_BLOCK.gameZoneRows;
+    const startBlock = this.startWindow.render(START_WINDOW.title, START_WINDOW.description, isShowLearnedWordsOption);
+    this.startMenu.appendChild(startBlock);
   }
 
   async getCardsAndStartGame(status = false) {
@@ -389,6 +393,7 @@ export default class EnglishPuzzle {
   async actionOnCloseButton() {
     this.backData.shortTermStatistics.removeEvents();
     this.backData.closeButton.modalWindow.removeEvents();
+    await this.checkWordsCollections();
     viewElement([this.gameForm], [this.startMenu]);
   }
 

--- a/rslang/src/scss/components/mini-games/english-puzzle/english-puzzle.scss
+++ b/rslang/src/scss/components/mini-games/english-puzzle/english-puzzle.scss
@@ -138,9 +138,10 @@
     align-items: center;
     width: 22px;
     height: 22px;
+    padding: 2px;
     cursor: pointer;
     transition: all 0.5s ease;
-    margin-top: 5px;
+    margin-top: 2px;
 }
 
 .sound-button_active {
@@ -319,7 +320,7 @@
 .result-block_statistic--title {
     margin: 0;
     font-size: 1.6rem;
-    width: 80px;
+    width: 100px;
 }
 
 .result-block_statistic--counter {
@@ -433,6 +434,7 @@
     align-items: center;
     height: 25px;
     width: 25px;
+    margin: 0 auto;
 }
 
 .result-row_text {


### PR DESCRIPTION
Проблема заключалась в том что проверка на создание стартового экрана осуществлялась только при первом запуске игры, после закрытия игры, стартовый экран сохранялся где можно было выбрать "изученные слова", с недостаточным количеством слов, что вызывало ошибку приложения, создан метод что вызывается после создания wrapper для стартового и после закрытия игры.

Также исправил стили, что убежали от изменения шрифта.

Добавил обвертку async/await для renderAuditionGame потаму что перед прогрузкой стартового небыло прелоадера, впоследствии увидил что у класса auditiongame функция render асинхронная, а в свиче в App.js небыло await